### PR TITLE
tweaks for pipeline compatability

### DIFF
--- a/core/tools/graph_compare.py
+++ b/core/tools/graph_compare.py
@@ -90,9 +90,9 @@ def k_most_similar_bp2(moduleLibraryPath, bp2Output, dataset):
     }
     res = []
 
-    for sequence in js_graph["motif_graphs"].keys():
+    for sequence in js_graph.keys():
         sequenceData = []
-        for y in js_graph["motif_graphs"][sequence].keys():
+        for y in js_graph[sequence].keys():
             graphAnalysis = {
                 "Graph": y,
                 "Value": [],
@@ -101,7 +101,7 @@ def k_most_similar_bp2(moduleLibraryPath, bp2Output, dataset):
 
             g1 = nx.Graph()
             g1.add_edges_from(
-                js_graph["motif_graphs"][sequence][str(y)]["edges"]
+                js_graph[sequence][str(y)]["edges"]
             )
             for x in range(0, len(data_string)):
                 g2 = nx.Graph()


### PR DESCRIPTION
- switches to ast.literal_eval. For whatever reason, the properties in the graph string are in single quotes which json.load(0 does not like. From my research, it's generally better to stick to json.loads() for security reasons, but since we are only using this internally, we can use ast.literal_eval() which is safer than eval(). Alternatively, we could have replaced the single quotes with double quotes in the string.
- fixes incorrect handling for input representative graphs (remove motif_graphs).